### PR TITLE
feat: add shareable URL parameter support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { downsampleRoute, minDistToRouteKm, routeBBox, type LatLon } from './geo
 import { overpass, buildChargerQuery, buildFoodQuery } from './overpass.ts'
 import { isFastCharger, isIndieFood, getChargerSockets, type OsmElement } from './filters.ts'
 import { setStatus, buildChargerCard, renderFoodList, initDrawer } from './ui.ts'
+import { parseUrlParams, buildUrlSearch } from './params.ts'
 
 // ─── DOM refs ────────────────────────────────────────────────────────────────
 
@@ -154,6 +155,7 @@ async function runPlan(): Promise<void> {
   planBtn.disabled = true
   clearAll()
   resultsDiv.innerHTML = ''
+  history.replaceState(null, '', buildUrlSearch(fromStr, toStr, detourKm, foodRadiusM))
 
   try {
     status('Geocoding locations…')
@@ -228,3 +230,18 @@ planBtn.addEventListener('click', () => {
 })
 
 sidebar.addEventListener('transitionend', () => map.invalidateSize())
+
+// ─── URL params ───────────────────────────────────────────────────────────────
+
+const urlParams = parseUrlParams(window.location.search)
+if (urlParams.from) fromInput.value = urlParams.from
+if (urlParams.to) toInput.value = urlParams.to
+if (urlParams.chargerDistance !== undefined) {
+  detourSlider.value = String(urlParams.chargerDistance)
+  detourVal.textContent = String(urlParams.chargerDistance)
+}
+if (urlParams.foodRadius !== undefined) {
+  foodSlider.value = String(urlParams.foodRadius)
+  foodVal.textContent = String(urlParams.foodRadius)
+}
+if (urlParams.from && urlParams.to) void runPlan()

--- a/src/params.ts
+++ b/src/params.ts
@@ -1,0 +1,75 @@
+/** URL parameter parsing and serialisation with input validation. */
+
+export interface RouteParams {
+  from: string
+  to: string
+  chargerDistance: number
+  foodRadius: number
+}
+
+const PLACE_MAX_LEN = 100
+
+export function sanitisePlace(raw: string): string | null {
+  const s = raw.trim()
+  if (!s || s.length > PLACE_MAX_LEN) return null
+  if (/<|>|javascript:/i.test(s)) return null
+  return s
+}
+
+export function parseNumericParam(
+  raw: string,
+  min: number,
+  max: number,
+  step: number,
+): number | null {
+  const n = parseInt(raw, 10)
+  if (!Number.isFinite(n)) return null
+  const clamped = Math.max(min, Math.min(max, n))
+  return Math.round(clamped / step) * step
+}
+
+export function parseUrlParams(search: string): Partial<RouteParams> {
+  const p = new URLSearchParams(search)
+  const result: Partial<RouteParams> = {}
+
+  const from = p.get('from')
+  if (from !== null) {
+    const s = sanitisePlace(from)
+    if (s) result.from = s
+  }
+
+  const to = p.get('to')
+  if (to !== null) {
+    const s = sanitisePlace(to)
+    if (s) result.to = s
+  }
+
+  const detour = p.get('charger_distance')
+  if (detour !== null) {
+    const n = parseNumericParam(detour, 1, 25, 1)
+    if (n !== null) result.chargerDistance = n
+  }
+
+  const food = p.get('food_radius')
+  if (food !== null) {
+    const n = parseNumericParam(food, 50, 600, 50)
+    if (n !== null) result.foodRadius = n
+  }
+
+  return result
+}
+
+export function buildUrlSearch(
+  from: string,
+  to: string,
+  chargerDistance: number,
+  foodRadius: number,
+): string {
+  const p = new URLSearchParams({
+    from,
+    to,
+    charger_distance: String(chargerDistance),
+    food_radius: String(foodRadius),
+  })
+  return '?' + p.toString()
+}

--- a/tests/params.test.ts
+++ b/tests/params.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest'
+import { sanitisePlace, parseNumericParam, parseUrlParams, buildUrlSearch } from '../src/params.ts'
+
+describe('sanitisePlace', () => {
+  it('returns trimmed string for valid input', () => {
+    expect(sanitisePlace('  Luton, UK  ')).toBe('Luton, UK')
+  })
+
+  it('returns null for empty string', () => {
+    expect(sanitisePlace('')).toBeNull()
+    expect(sanitisePlace('   ')).toBeNull()
+  })
+
+  it('returns null for strings over 100 chars', () => {
+    expect(sanitisePlace('A'.repeat(101))).toBeNull()
+    expect(sanitisePlace('A'.repeat(100))).toBe('A'.repeat(100))
+  })
+
+  it('returns null when string contains <', () => {
+    expect(sanitisePlace('<script>alert(1)</script>')).toBeNull()
+  })
+
+  it('returns null when string contains >', () => {
+    expect(sanitisePlace('foo > bar')).toBeNull()
+  })
+
+  it('returns null when string contains javascript:', () => {
+    expect(sanitisePlace('javascript:alert(1)')).toBeNull()
+    expect(sanitisePlace('JAVASCRIPT:void(0)')).toBeNull()
+  })
+
+  it('accepts place names with apostrophes, commas, hyphens, accents', () => {
+    expect(sanitisePlace("King's Cross, London")).toBe("King's Cross, London")
+    expect(sanitisePlace('Kraków')).toBe('Kraków')
+    expect(sanitisePlace('Stoke-on-Trent')).toBe('Stoke-on-Trent')
+  })
+})
+
+describe('parseNumericParam', () => {
+  it('parses a valid integer within range', () => {
+    expect(parseNumericParam('5', 1, 25, 1)).toBe(5)
+  })
+
+  it('clamps a value below minimum up to min', () => {
+    expect(parseNumericParam('0', 1, 25, 1)).toBe(1)
+    expect(parseNumericParam('-99', 1, 25, 1)).toBe(1)
+  })
+
+  it('clamps a value above maximum down to max', () => {
+    expect(parseNumericParam('999', 1, 25, 1)).toBe(25)
+  })
+
+  it('snaps to the nearest step', () => {
+    expect(parseNumericParam('175', 50, 600, 50)).toBe(200) // 175/50=3.5 → 4 → 200
+    expect(parseNumericParam('120', 50, 600, 50)).toBe(100) // 120/50=2.4 → 2 → 100
+  })
+
+  it('returns null for non-numeric input', () => {
+    expect(parseNumericParam('abc', 1, 25, 1)).toBeNull()
+    expect(parseNumericParam('', 1, 25, 1)).toBeNull()
+    expect(parseNumericParam('NaN', 1, 25, 1)).toBeNull()
+  })
+
+  it('truncates decimals rather than rejecting them', () => {
+    expect(parseNumericParam('5.9', 1, 25, 1)).toBe(5)
+  })
+})
+
+describe('parseUrlParams', () => {
+  it('parses all four valid params', () => {
+    const r = parseUrlParams('?from=Luton&to=Newquay&charger_distance=10&food_radius=200')
+    expect(r.from).toBe('Luton')
+    expect(r.to).toBe('Newquay')
+    expect(r.chargerDistance).toBe(10)
+    expect(r.foodRadius).toBe(200)
+  })
+
+  it('returns empty object for empty search string', () => {
+    expect(parseUrlParams('')).toEqual({})
+  })
+
+  it('omits params with invalid place names', () => {
+    const r = parseUrlParams('?from=<script>&to=ValidPlace')
+    expect(r.from).toBeUndefined()
+    expect(r.to).toBe('ValidPlace')
+  })
+
+  it('omits params with non-numeric slider values', () => {
+    const r = parseUrlParams('?charger_distance=abc&food_radius=not-a-number')
+    expect(r.chargerDistance).toBeUndefined()
+    expect(r.foodRadius).toBeUndefined()
+  })
+
+  it('clamps out-of-range charger_distance to valid range', () => {
+    const r = parseUrlParams('?charger_distance=999')
+    expect(r.chargerDistance).toBe(25)
+  })
+
+  it('clamps out-of-range food_radius to valid range and snaps to step', () => {
+    expect(parseUrlParams('?food_radius=0').foodRadius).toBe(50)
+    expect(parseUrlParams('?food_radius=9999').foodRadius).toBe(600)
+  })
+
+  it('ignores unknown params silently', () => {
+    const r = parseUrlParams('?from=London&evil=<script>&to=Bristol')
+    expect(r.from).toBe('London')
+    expect(r.to).toBe('Bristol')
+  })
+})
+
+describe('buildUrlSearch', () => {
+  it('builds a round-trippable query string', () => {
+    const qs = buildUrlSearch('Luton', 'Newquay', 5, 150)
+    const r = parseUrlParams(qs)
+    expect(r.from).toBe('Luton')
+    expect(r.to).toBe('Newquay')
+    expect(r.chargerDistance).toBe(5)
+    expect(r.foodRadius).toBe(150)
+  })
+
+  it('URL-encodes special characters in place names', () => {
+    const qs = buildUrlSearch("King's Cross", 'Bristol', 5, 150)
+    expect(qs).toContain('King')
+    const r = parseUrlParams(qs)
+    expect(r.from).toBe("King's Cross")
+  })
+})


### PR DESCRIPTION
## Summary

- Encodes all four form inputs as URL query params so any search can be shared or bookmarked as a direct link: `?from=Luton&to=Newquay&charger_distance=5&food_radius=150`
- On page load, valid params are applied to the form and the plan auto-runs if both `from` and `to` are present
- `history.replaceState` keeps the URL in sync after every plan run

## Validation

Input is validated in a dedicated `src/params.ts` module (no DOM dependency, fully unit-tested):

- **Place names**: trimmed, max 100 chars, rejects `<`, `>`, and `javascript:` to prevent injection via the query string
- **Numeric params**: parsed as integers, clamped to the slider's valid range, snapped to the slider's step value — invalid/non-numeric values are silently dropped rather than causing an error

## Test plan

- [ ] 22 new unit tests in `tests/params.test.ts` covering sanitisation boundaries, clamping, step-snapping, round-trip serialisation, and injection attempts
- [ ] Open the app with a full query string and verify the form populates and auto-runs
- [ ] Run a plan manually and verify the URL updates in the address bar
- [ ] Try injecting `<script>` or `javascript:` in the `from` param and verify it is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)