### PR TITLE
fix: remove hardcoded default values from route inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,11 @@
     <div id="inputs-row">
       <div class="field">
         <label for="from-input">From</label>
-        <input type="text" id="from-input" value="Luton, UK" placeholder="e.g. Luton, UK">
+        <input type="text" id="from-input" placeholder="e.g. Luton, UK">
       </div>
       <div class="field">
         <label for="to-input">To</label>
-        <input type="text" id="to-input" value="Newquay, UK" placeholder="e.g. Newquay, UK">
+        <input type="text" id="to-input" placeholder="e.g. Newquay, UK">
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- Removes `value="Luton, UK"` and `value="Newquay, UK"` from the form inputs — these were test data left in from development
- Placeholder text (`e.g. Luton, UK`) remains as a hint

## Test plan

- [ ] Form inputs are empty on fresh load
- [ ] Placeholder hints are still visible
- [ ] URL params still populate the fields correctly when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)